### PR TITLE
updated container_path and host_path

### DIFF
--- a/airflow/contrib/executors/astronomer_mesos_executor.py
+++ b/airflow/contrib/executors/astronomer_mesos_executor.py
@@ -141,8 +141,8 @@ class AirflowMesosScheduler(mesos.interface.Scheduler):
                 container = mesos_pb2.ContainerInfo()
                 container.type = 1 # mesos_pb2.ContainerInfo.Type.DOCKER
                 volume = container.volumes.add()
-                volume.host_path = "/airflow/logs"
-                volume.container_path = "/airflow/logs"
+                volume.host_path = "/airflow_home/logs"
+                volume.container_path = "/airflow_home/logs"
                 volume.mode = 1 # mesos_pb2.Volume.Mode.RW
 
                 volume = container.volumes.add()


### PR DESCRIPTION
Hold off on merging this until testing has been done in dev cluster. This remaps the host and container path to use airflow_home to be consistent with changes in docker_airflow and astronomer_infrastructure