### PR TITLE
get docker image tag for astronomerio/airflow from env. default to as…

### DIFF
--- a/airflow/contrib/executors/astronomer_mesos_executor.py
+++ b/airflow/contrib/executors/astronomer_mesos_executor.py
@@ -151,7 +151,7 @@ class AirflowMesosScheduler(mesos.interface.Scheduler):
                 volume.mode = 1 # mesos_pb2.Volume.Mode.RW
 
                 docker = mesos_pb2.ContainerInfo.DockerInfo()
-                docker.image = "astronomerio/airflow"
+                docker.image = os.getenv("DOCKER_AIRFLOW_IMAGE_TAG", "astronomerio/airflow")
                 docker.force_pull_image = True
 
                 container.docker.MergeFrom(docker)


### PR DESCRIPTION
this will allow us to pin versions in production or default to the latest tag in staging. 