### PR TITLE
Fix bug where status key is not present when there's an error pulling the docker image

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -161,7 +161,7 @@ class DockerOperator(BaseOperator):
             logging.info('Pulling docker image ' + image)
             for l in self.cli.pull(image, stream=True):
                 output = json.loads(l.decode('utf-8'))
-                print('output =', output)
+
                 # status key is not present when there's an error pulling the docker image
                 status = output.get('status')
                 if status is not None:

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -161,7 +161,13 @@ class DockerOperator(BaseOperator):
             logging.info('Pulling docker image ' + image)
             for l in self.cli.pull(image, stream=True):
                 output = json.loads(l.decode('utf-8'))
-                logging.info("{}".format(output['status']))
+                print('output =', output)
+                # status key is not present when there's an error pulling the docker image
+                status = output.get('status')
+                if status is not None:
+                    logging.info('{}'.format(status))
+                else:
+                    logging.info('* status is missing from output = {}'.format(output))
 
         cpu_shares = int(round(self.cpus * 1024))
 


### PR DESCRIPTION
Fixes:
- https://sentry.astronomer.io/sentry/clickstream-redshift-dags/issues/455/
- https://sentry.astronomer.io/sentry/clickstream-redshift-dags/issues/457/
- https://sentry.astronomer.io/sentry/clickstream-redshift-dags/issues/454/
