### PR TITLE
Adding support for dictionary int attr in templating

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2282,6 +2282,8 @@ class BaseOperator(object):
             result = {
                 k: rt("{}[{}]".format(attr, k), v, context)
                 for k, v in list(content.items())}
+        elif isinstance(content, six.integer_types):
+            result = content
         else:
             param_type = type(content)
             msg = (


### PR DESCRIPTION
Add support for integer types in dictionaries passed to Operators that will be traversed for templating. Previously would return error, now returns integer in it's original form inline with the dict traversal.