### PR TITLE
Clamp snowflake version to 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ s3 = [
 ]
 samba = ['pysmbclient>=0.1.3']
 slack = ['slackclient>=1.0.0']
-snowflake = ['snowflake-connector-python>=1.4.7']
+snowflake = ['snowflake-connector-python==1.4.1']
 statsd = ['statsd>=3.0.1, <4.0']
 vertica = ['vertica-python>=0.5.1']
 ldap = ['ldap3>=0.9.9.1']


### PR DESCRIPTION
@andscoop found out that the snowflake version needs to be clamped to `1.4.1` for now [this](https://support.snowflake.net/s/article/ka70Z000000L0fcQAC/Error-OpenSSL-crypto-Error-when-connecting-with-Python-Connector) error which has resurfaced in `1.4.7`.