### PR TITLE
Hide removed DAGs in webserver dag list

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1870,12 +1870,22 @@ class HomeView(AdminIndexView):
             }
 
         all_dag_ids = sorted(set(orm_dags.keys()) | set(webserver_dags.keys()))
+
+        # Astronomer Edit
+        # https://github.com/astronomerio/engineering/issues/216
+
+        # Filter dags down to only those found in webserver dag bag (active dags)
+        dag_list = []
+        for dag_id in all_dag_ids:
+            if dag_id in dagbag.dags:
+                dag_list.append(dag_id)
+
         return self.render(
             'airflow/dags.html',
             webserver_dags=webserver_dags,
             orm_dags=orm_dags,
             hide_paused=hide_paused,
-            all_dag_ids=all_dag_ids)
+            all_dag_ids=dag_list)
 
 
 class QueryView(wwwutils.DataProfilingMixin, BaseView):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1871,21 +1871,22 @@ class HomeView(AdminIndexView):
 
         all_dag_ids = sorted(set(orm_dags.keys()) | set(webserver_dags.keys()))
 
-        # Astronomer Edit
-        # https://github.com/astronomerio/engineering/issues/216
+        # default to displaying all dags
+        display_dag_ids = all_dag_ids
 
-        # Filter dags down to only those found in webserver dag bag (active dags)
-        dag_list = []
-        for dag_id in all_dag_ids:
-            if dag_id in dagbag.dags:
-                dag_list.append(dag_id)
+        if conf.getboolean('webserver', 'hide_removed_dags'):
+            # Filter dags to only those in webserver dag bag (dags in the file system)
+            display_dag_ids = []
+            for dag_id in all_dag_ids:
+                if dag_id in dagbag.dags:
+                    display_dag_ids.append(dag_id)
 
         return self.render(
             'airflow/dags.html',
             webserver_dags=webserver_dags,
             orm_dags=orm_dags,
             hide_paused=hide_paused,
-            all_dag_ids=dag_list)
+            all_dag_ids=display_dag_ids)
 
 
 class QueryView(wwwutils.DataProfilingMixin, BaseView):


### PR DESCRIPTION
https://github.com/astronomerio/engineering/issues/216

Assuming the webserver and scheduler are in sync, this will hide dags that are in the database and no longer in either dagbag.  No files will be removed, if the dag is re-added, it will show up again.